### PR TITLE
Trying FF run with Date library update by Dev

### DIFF
--- a/.github/workflows/wf3_firefox_dailyRun.yml
+++ b/.github/workflows/wf3_firefox_dailyRun.yml
@@ -1,9 +1,10 @@
 name: Cypress firefox-Browser Testing - DailyRun
 
-on: [fork]
-  # schedule:
+on: 
+#[fork]
+   schedule:
      # UTC time is setup here i.e. 4:00 AM (daily) which is equal to 9:30 AM IST
-  #  - cron: '35 10 * * *'
+    - cron: '30 12 * * *'
 
 jobs:
   cypress-crossbrowser-testing:
@@ -17,7 +18,7 @@ jobs:
       # and run all Cypress tests
       - name: Cypress run tests --spec cypress/e2e/kiosk/specs/ui/loginauthentication.spec.js
         uses: cypress-io/github-action@v4
-        timeout-minutes: 30
+        timeout-minutes: 15
         with:
           browser: firefox
           record: true


### PR DESCRIPTION
Dev team informed they have made changes in date library and suggested to run on FF to check the behavior now.

Also reduce timeout to 15minutes to stop run automatically by timeout

@dipalith  pleae approve and merge